### PR TITLE
feat: PQ key generation, auto-suite seal/open (v0.2.0-alpha)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Checkout aegis-core sibling for path dependencies
-        uses: actions/checkout@v4
-        with:
-          repository: mlaify/aegis-core
-          path: aegis-core
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$BRANCH" https://github.com/mlaify/aegis-core.git aegis-core 2>/dev/null || \
+          git clone --depth 1 --branch main https://github.com/mlaify/aegis-core.git aegis-core
       - name: Expose ../aegis-core path
         run: ln -s "$GITHUB_WORKSPACE/aegis-core" "$GITHUB_WORKSPACE/../aegis-core"
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,10 +28,17 @@ dependencies = [
  "base64",
  "blake3",
  "chacha20poly1305",
+ "ed25519-dalek",
+ "hkdf",
+ "pqcrypto-dilithium",
+ "pqcrypto-kyber",
+ "pqcrypto-traits",
  "rand",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -42,6 +49,7 @@ dependencies = [
  "base64",
  "rand",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -65,6 +73,7 @@ dependencies = [
  "aegis-crypto",
  "aegis-identity",
  "aegis-proto",
+ "base64",
  "clap",
  "reqwest",
  "serde_json",
@@ -167,6 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +199,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -205,6 +229,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -310,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +403,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +459,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -411,6 +522,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -526,16 +643,34 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -576,6 +711,24 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -876,6 +1029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1249,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "pqcrypto-dilithium"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685de0fa68c6786559d5fcdaa414f0cd68ef3f5d162f61823bd7424cd276726f"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-internals"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
+dependencies = [
+ "cc",
+ "dunce",
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c00293cf898859d0c771455388054fd69ab712263c73fdc7f287a39b1ba000"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-traits"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1319,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1193,6 +1416,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1347,10 +1579,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "slab"
@@ -1372,6 +1624,16 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2065,6 +2327,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2407,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ aegis-identity = { path = "../aegis-core/crates/aegis-identity" }
 aegis-api-types = { path = "../aegis-core/crates/aegis-api-types" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -1,11 +1,13 @@
 use std::fs;
 
+use aegis_crypto::HybridPqKeyBundle;
 use aegis_identity::{
-    decode_local_dev_signing_key, generate_local_dev_signing_key_material,
-    local_dev_public_key_b64, parse_identity_id, LocalDevSigningKeyMaterial,
-    LOCAL_DEV_SIGNING_ALGORITHM,
+    decode_local_dev_signing_key, generate_local_dev_signing_key_material, parse_identity_id,
+    HybridPqPrivateKeyMaterial, LocalDevSigningKeyMaterial, ALG_ED25519, ALG_MLDSA65, ALG_MLKEM768,
+    ALG_X25519, SUITE_HYBRID_PQ,
 };
 use aegis_proto::{IdentityDocument, IdentityId, PublicKeyRecord};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Args, Subcommand};
 use uuid::Uuid;
 
@@ -22,6 +24,10 @@ pub enum IdentityCommand {
 pub struct InitArgs {
     #[arg(long)]
     pub alias: Option<String>,
+    /// Generate legacy demo signing key material in addition to hybrid PQ keys.
+    /// Only needed when interoperating with v0.1 local development tooling.
+    #[arg(long, default_value_t = false)]
+    pub include_demo_key: bool,
 }
 
 #[derive(Debug, Args)]
@@ -35,43 +41,85 @@ pub fn run(cmd: IdentityCommand) -> Result<(), Box<dyn std::error::Error>> {
         IdentityCommand::Init(args) => {
             let id = IdentityId(format!("amp:did:key:local-{}", Uuid::new_v4().simple()));
             let alias_list = args.alias.into_iter().collect::<Vec<_>>();
-            let signing_key = generate_local_dev_signing_key_material("sig-local-dev-1");
-            let signing_public_b64 = local_dev_public_key_b64(&signing_key)?;
+
+            // --- Generate hybrid PQ key bundle ---
+            let bundle = HybridPqKeyBundle::generate();
+
+            let pq_material = HybridPqPrivateKeyMaterial {
+                identity_id: id.0.clone(),
+                algorithm: HybridPqPrivateKeyMaterial::algorithm_marker().to_string(),
+                x25519_private_key_b64: STANDARD.encode(bundle.x25519_private_key_bytes),
+                kyber768_secret_key_b64: STANDARD.encode(&bundle.kyber768_secret_key_bytes),
+                ed25519_signing_seed_b64: STANDARD.encode(bundle.ed25519_signing_seed_bytes),
+                dilithium3_secret_key_b64: STANDARD.encode(&bundle.dilithium3_secret_key_bytes),
+            };
+
             let identity_doc = IdentityDocument {
                 version: 1,
                 identity_id: id.clone(),
                 aliases: alias_list,
-                signing_keys: vec![PublicKeyRecord {
-                    key_id: signing_key.key_id.clone(),
-                    algorithm: LOCAL_DEV_SIGNING_ALGORITHM.to_string(),
-                    public_key_b64: signing_public_b64,
-                }],
-                encryption_keys: vec![],
-                supported_suites: vec!["AMP-DEMO-XCHACHA20POLY1305".to_string()],
+                signing_keys: vec![
+                    PublicKeyRecord {
+                        key_id: "sig-ed25519-1".to_string(),
+                        algorithm: ALG_ED25519.to_string(),
+                        public_key_b64: bundle.ed25519_verifying_key_b64(),
+                    },
+                    PublicKeyRecord {
+                        key_id: "sig-mldsa65-1".to_string(),
+                        algorithm: ALG_MLDSA65.to_string(),
+                        public_key_b64: bundle.dilithium3_public_key_b64(),
+                    },
+                ],
+                encryption_keys: vec![
+                    PublicKeyRecord {
+                        key_id: "enc-x25519-1".to_string(),
+                        algorithm: ALG_X25519.to_string(),
+                        public_key_b64: bundle.x25519_public_key_b64(),
+                    },
+                    PublicKeyRecord {
+                        key_id: "enc-mlkem768-1".to_string(),
+                        algorithm: ALG_MLKEM768.to_string(),
+                        public_key_b64: bundle.kyber768_public_key_b64(),
+                    },
+                ],
+                supported_suites: vec![SUITE_HYBRID_PQ.to_string()],
                 relay_endpoints: vec![],
                 signature: None,
             };
 
+            // Persist identity document
             let identity_path = state::identity_doc_path(&id.0);
             state::ensure_parent_dir(&identity_path)?;
             fs::write(&identity_path, serde_json::to_string_pretty(&identity_doc)?)?;
 
+            // Persist hybrid PQ private key material
+            let pq_key_path = state::pq_key_material_path(&id.0);
+            state::ensure_parent_dir(&pq_key_path)?;
+            fs::write(&pq_key_path, serde_json::to_string_pretty(&pq_material)?)?;
+
+            // Set as default identity
             let default_path = state::default_identity_path();
             state::ensure_parent_dir(&default_path)?;
             fs::write(&default_path, format!("{}\n", id.0))?;
 
-            let signing_key_path = state::signing_key_material_path(&id.0);
-            state::ensure_parent_dir(&signing_key_path)?;
-            fs::write(
-                &signing_key_path,
-                serde_json::to_string_pretty(&signing_key)?,
-            )?;
+            // Optionally write legacy demo signing key for v0.1 compat
+            if args.include_demo_key {
+                let signing_key = generate_local_dev_signing_key_material("sig-local-dev-1");
+                let signing_key_path = state::signing_key_material_path(&id.0);
+                state::ensure_parent_dir(&signing_key_path)?;
+                fs::write(
+                    &signing_key_path,
+                    serde_json::to_string_pretty(&signing_key)?,
+                )?;
+                println!("demo_signing_key {}", signing_key_path.display());
+            }
 
-            println!("initialized local identity");
+            println!("initialized hybrid PQ identity");
             println!("identity {}", id.0);
+            println!("suite {}", SUITE_HYBRID_PQ);
             println!("stored {}", identity_path.display());
+            println!("pq_key {}", pq_key_path.display());
             println!("default {}", default_path.display());
-            println!("signing_key {}", signing_key_path.display());
             if !identity_doc.aliases.is_empty() {
                 println!("aliases {}", identity_doc.aliases.join(","));
             }
@@ -96,7 +144,15 @@ pub fn run(cmd: IdentityCommand) -> Result<(), Box<dyn std::error::Error>> {
             println!("encryption_keys {}", doc.encryption_keys.len());
             println!("signature {}", doc.signature.as_deref().unwrap_or("<none>"));
             println!(
-                "local_signing_key {}",
+                "pq_key_material {}",
+                if read_pq_key_material(&doc.identity_id.0).is_ok() {
+                    "present"
+                } else {
+                    "<none>"
+                }
+            );
+            println!(
+                "demo_signing_key {}",
                 if read_signing_key_material(&doc.identity_id.0).is_ok() {
                     "present"
                 } else {
@@ -154,6 +210,17 @@ pub fn read_identity_document(
     Ok(doc)
 }
 
+pub fn read_pq_key_material(
+    identity_id: &str,
+) -> Result<HybridPqPrivateKeyMaterial, Box<dyn std::error::Error>> {
+    let path = state::pq_key_material_path(identity_id);
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read PQ key material {}: {}", path.display(), e))?;
+    let material: HybridPqPrivateKeyMaterial = serde_json::from_str(&raw)
+        .map_err(|e| format!("invalid PQ key material {}: {}", path.display(), e))?;
+    Ok(material)
+}
+
 pub fn read_signing_key_material(
     identity_id: &str,
 ) -> Result<LocalDevSigningKeyMaterial, Box<dyn std::error::Error>> {
@@ -182,6 +249,14 @@ fn list_identity_documents() -> Result<Vec<IdentityDocument>, Box<dyn std::error
     for entry in fs::read_dir(&dir)? {
         let path = entry?.path();
         if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        // Skip key material files — only read identity documents
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if filename.contains(".signing-key") || filename.contains(".pq-key") {
             continue;
         }
         let raw = fs::read_to_string(path)?;

--- a/src/commands/message.rs
+++ b/src/commands/message.rs
@@ -4,10 +4,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use aegis_crypto::{DemoSuite, EnvelopeSigner, EnvelopeVerifier, PayloadCipher};
-use aegis_identity::decode_local_dev_signing_key;
-use aegis_identity::parse_identity_id;
-use aegis_proto::{Envelope, MessageBody, PrivateHeaders, PrivatePayload};
+use aegis_crypto::{DemoSuite, EnvelopeSigner, EnvelopeVerifier, HybridPqSuite, PayloadCipher};
+use aegis_identity::{
+    decode_local_dev_signing_key, parse_identity_id, ALG_ED25519, ALG_MLDSA65, ALG_MLKEM768,
+    ALG_X25519, SUITE_HYBRID_PQ,
+};
+use aegis_proto::{Envelope, IdentityId, MessageBody, PrivateHeaders, PrivatePayload, SuiteId};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Args, Subcommand};
 
 use crate::{commands::identity, state};
@@ -29,8 +32,9 @@ pub struct SealArgs {
     pub subject: Option<String>,
     #[arg(long)]
     pub body: String,
+    /// Passphrase for demo (v0.1) suite. Required when recipient does not support hybrid PQ.
     #[arg(long)]
-    pub passphrase: String,
+    pub passphrase: Option<String>,
     #[arg(long)]
     pub out: Option<PathBuf>,
 }
@@ -39,8 +43,9 @@ pub struct SealArgs {
 pub struct OpenArgs {
     #[arg(long)]
     pub input: PathBuf,
+    /// Passphrase for demo (v0.1) suite envelopes.
     #[arg(long)]
-    pub passphrase: String,
+    pub passphrase: Option<String>,
     #[arg(long)]
     pub out: Option<PathBuf>,
 }
@@ -53,125 +58,288 @@ pub struct ListArgs {
 
 pub fn run(cmd: MessageCommand) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        MessageCommand::Seal(args) => {
-            let suite = DemoSuite::from_passphrase(&args.passphrase);
-            let recipient_id = parse_identity_id(&args.to)
-                .map_err(|_| format!("invalid recipient identity id: {}", args.to))?;
-            let sender_hint = match args.from {
-                Some(from) => Some(
-                    parse_identity_id(&from)
-                        .map_err(|_| format!("invalid sender identity id: {}", from))?,
-                ),
-                None => match identity::read_default_identity_id()? {
-                    Some(id) => Some(
-                        parse_identity_id(&id)
-                            .map_err(|_| format!("invalid default identity id: {}", id))?,
-                    ),
-                    None => {
-                        return Err(
-                            "no sender identity provided and no default identity configured; run `aegit id init` or pass `--from`"
-                                .into(),
-                        )
-                    }
-                },
-            };
+        MessageCommand::Seal(args) => seal(args),
+        MessageCommand::Open(args) => open(args),
+        MessageCommand::List(args) => list(args),
+    }
+}
 
-            let payload = PrivatePayload {
-                private_headers: PrivateHeaders {
-                    subject: args.subject,
-                    thread_id: None,
-                    in_reply_to: None,
-                },
-                body: MessageBody {
-                    mime: "text/plain".to_string(),
-                    content: args.body,
-                },
-                attachments: vec![],
-                extensions: serde_json::json!({}),
-            };
+fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let recipient_id = parse_identity_id(&args.to)
+        .map_err(|_| format!("invalid recipient identity id: {}", args.to))?;
 
-            let encrypted = suite.encrypt_payload(&payload)?;
-            let mut envelope =
-                Envelope::new(recipient_id, sender_hint, suite.suite_id(), encrypted);
-            if let Some(sender_identity) = envelope.sender_hint.as_ref() {
-                let signing_material = identity::read_signing_key_material(&sender_identity.0)?;
+    let sender_hint = resolve_sender(args.from)?;
+
+    let payload = PrivatePayload {
+        private_headers: PrivateHeaders {
+            subject: args.subject,
+            thread_id: None,
+            in_reply_to: None,
+        },
+        body: MessageBody {
+            mime: "text/plain".to_string(),
+            content: args.body,
+        },
+        attachments: vec![],
+        extensions: serde_json::json!({}),
+    };
+
+    let recipient_doc = identity::read_identity_document(&recipient_id.0).ok();
+    let supports_pq = recipient_doc
+        .as_ref()
+        .map(|doc| doc.supported_suites.iter().any(|s| s == SUITE_HYBRID_PQ))
+        .unwrap_or(false);
+
+    if supports_pq {
+        let doc = recipient_doc.as_ref().unwrap();
+
+        let x25519_pk_b64 = doc
+            .encryption_keys
+            .iter()
+            .find(|k| k.algorithm == ALG_X25519)
+            .map(|k| k.public_key_b64.as_str())
+            .ok_or("recipient identity missing X25519 encryption key")?;
+        let kyber_pk_b64 = doc
+            .encryption_keys
+            .iter()
+            .find(|k| k.algorithm == ALG_MLKEM768)
+            .map(|k| k.public_key_b64.as_str())
+            .ok_or("recipient identity missing ML-KEM-768 encryption key")?;
+
+        let recipient_x25519_pk: [u8; 32] = STANDARD
+            .decode(x25519_pk_b64)?
+            .try_into()
+            .map_err(|_| "invalid X25519 public key length")?;
+        let recipient_kyber_pk = STANDARD.decode(kyber_pk_b64)?;
+
+        let sender_id = sender_hint.as_ref().ok_or(
+            "sender identity required for hybrid PQ seal; run `aegit id init` or pass --from",
+        )?;
+        let pq_material = identity::read_pq_key_material(&sender_id.0)?;
+
+        let ed25519_seed: [u8; 32] = STANDARD
+            .decode(&pq_material.ed25519_signing_seed_b64)?
+            .try_into()
+            .map_err(|_| "invalid Ed25519 seed length")?;
+        let dilithium3_sk = STANDARD.decode(&pq_material.dilithium3_secret_key_b64)?;
+
+        let suite = HybridPqSuite::for_sender_with_recipient_keys(
+            ed25519_seed,
+            dilithium3_sk,
+            recipient_x25519_pk,
+            recipient_kyber_pk,
+        );
+
+        let encrypted = suite.encrypt_payload(&payload)?;
+        let mut envelope = Envelope::new(
+            recipient_id.clone(),
+            sender_hint.clone(),
+            suite.suite_id(),
+            encrypted,
+        );
+        let classical_sig = suite.sign_envelope(&envelope)?;
+        let pq_sig = suite.sign_envelope_pq(&envelope)?;
+        envelope.outer_signature_b64 = Some(classical_sig);
+        envelope.outer_pq_signature_b64 = Some(pq_sig);
+        write_envelope(envelope, args.out)?;
+    } else {
+        let passphrase = args
+            .passphrase
+            .ok_or("--passphrase required when recipient does not support hybrid PQ suite")?;
+        let suite = DemoSuite::from_passphrase(&passphrase);
+        let encrypted = suite.encrypt_payload(&payload)?;
+        let mut envelope = Envelope::new(
+            recipient_id,
+            sender_hint.clone(),
+            suite.suite_id(),
+            encrypted,
+        );
+        if let Some(sender) = sender_hint.as_ref() {
+            if let Ok(signing_material) = identity::read_signing_key_material(&sender.0) {
                 let signing_key = decode_local_dev_signing_key(&signing_material)?;
                 let signing_suite = DemoSuite::from_signing_key_bytes(&signing_key)?;
                 let signature = signing_suite.sign_envelope(&envelope)?;
                 envelope.outer_signature_b64 = Some(signature);
             }
-
-            let out = args.out.unwrap_or_else(|| {
-                state::sealed_envelope_path(
-                    &envelope.recipient_id.0,
-                    &envelope.envelope_id.0.to_string(),
-                )
-            });
-            state::ensure_parent_dir(&out)?;
-            fs::write(&out, envelope.to_json_pretty()?)?;
-            println!("sealed {}", out.display());
-            println!("id {}", envelope.envelope_id.0);
-            println!("to {}", envelope.recipient_id.0);
         }
-        MessageCommand::Open(args) => {
-            let suite = DemoSuite::from_passphrase(&args.passphrase);
-            let raw = fs::read_to_string(&args.input)?;
-            let envelope = Envelope::from_json(&raw)?;
-            let signature_status = signature_status(&envelope);
-            println!("signature_status {}", signature_status.label());
-            if let Some(reason) = signature_status.reason() {
-                println!("signature_detail {}", reason);
-            }
-            let payload = suite.decrypt_payload(&envelope.payload)?;
-            let out = args.out.unwrap_or_else(|| {
-                state::opened_payload_path(
-                    &envelope.recipient_id.0,
-                    &envelope.envelope_id.0.to_string(),
-                )
-            });
-            state::ensure_parent_dir(&out)?;
-            fs::write(&out, serde_json::to_string_pretty(&payload)?)?;
-
-            println!("opened {}", args.input.display());
-            println!("payload {}", out.display());
-            println!("id {}", envelope.envelope_id.0);
-            println!("to {}", envelope.recipient_id.0);
-            println!(
-                "from {}",
-                envelope
-                    .sender_hint
-                    .as_ref()
-                    .map(|i| i.0.as_str())
-                    .unwrap_or("<anonymous>")
-            );
-            println!(
-                "subject {}",
-                payload
-                    .private_headers
-                    .subject
-                    .as_deref()
-                    .unwrap_or("<none>")
-            );
-            println!("{}", payload.body.content);
-        }
-        MessageCommand::List(args) => {
-            let dir = state::fetched_envelope_dir(&args.recipient);
-            let entries = read_fetched_envelopes(&dir)?;
-
-            println!("recipient {}", args.recipient);
-            println!("count {}", entries.len());
-            for envelope in entries {
-                println!(
-                    "{} {} {}",
-                    envelope.created_at.to_rfc3339(),
-                    envelope.envelope_id.0,
-                    envelope_path(&dir, &envelope.envelope_id.0.to_string()).display()
-                );
-            }
-        }
+        write_envelope(envelope, args.out)?;
     }
 
     Ok(())
+}
+
+fn write_envelope(
+    envelope: Envelope,
+    out_path: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let out = out_path.unwrap_or_else(|| {
+        state::sealed_envelope_path(
+            &envelope.recipient_id.0,
+            &envelope.envelope_id.0.to_string(),
+        )
+    });
+    state::ensure_parent_dir(&out)?;
+    fs::write(&out, envelope.to_json_pretty()?)?;
+    println!("sealed {}", out.display());
+    println!("id {}", envelope.envelope_id.0);
+    println!("to {}", envelope.recipient_id.0);
+    println!(
+        "suite {}",
+        match &envelope.suite_id {
+            SuiteId::HybridX25519MlKem768Ed25519MlDsa65 => SUITE_HYBRID_PQ,
+            SuiteId::DemoXChaCha20Poly1305 => "AMP-DEMO-XCHACHA20POLY1305",
+            SuiteId::HybridPqPlaceholder => "AMP-HYBRID-PQ-PLACEHOLDER",
+        }
+    );
+    Ok(())
+}
+
+fn open(args: OpenArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let raw = fs::read_to_string(&args.input)?;
+    let envelope = Envelope::from_json(&raw)?;
+
+    let payload = match &envelope.suite_id {
+        SuiteId::HybridX25519MlKem768Ed25519MlDsa65 => open_hybrid_pq(&envelope)?,
+        _ => {
+            let passphrase = args
+                .passphrase
+                .ok_or("--passphrase required for demo suite envelopes")?;
+            let suite = DemoSuite::from_passphrase(&passphrase);
+            let sig_status = demo_signature_status(&envelope);
+            println!("signature_status {}", sig_status.label());
+            if let Some(reason) = sig_status.reason() {
+                println!("signature_detail {}", reason);
+            }
+            suite.decrypt_payload(&envelope.payload)?
+        }
+    };
+
+    let out = args.out.unwrap_or_else(|| {
+        state::opened_payload_path(
+            &envelope.recipient_id.0,
+            &envelope.envelope_id.0.to_string(),
+        )
+    });
+    state::ensure_parent_dir(&out)?;
+    fs::write(&out, serde_json::to_string_pretty(&payload)?)?;
+
+    println!("opened {}", args.input.display());
+    println!("payload {}", out.display());
+    println!("id {}", envelope.envelope_id.0);
+    println!("to {}", envelope.recipient_id.0);
+    println!(
+        "from {}",
+        envelope
+            .sender_hint
+            .as_ref()
+            .map(|i| i.0.as_str())
+            .unwrap_or("<anonymous>")
+    );
+    println!(
+        "subject {}",
+        payload
+            .private_headers
+            .subject
+            .as_deref()
+            .unwrap_or("<none>")
+    );
+    println!("{}", payload.body.content);
+    Ok(())
+}
+
+fn open_hybrid_pq(envelope: &Envelope) -> Result<PrivatePayload, Box<dyn std::error::Error>> {
+    let recipient_id = &envelope.recipient_id.0;
+
+    let pq_material = identity::read_pq_key_material(recipient_id).map_err(|_| {
+        format!(
+            "no PQ key material for {}; cannot open hybrid PQ envelope",
+            recipient_id
+        )
+    })?;
+
+    let x25519_sk: [u8; 32] = STANDARD
+        .decode(&pq_material.x25519_private_key_b64)?
+        .try_into()
+        .map_err(|_| "invalid X25519 private key length")?;
+    let kyber768_sk = STANDARD.decode(&pq_material.kyber768_secret_key_b64)?;
+
+    let (sender_ed_vk, sender_dil_pk) = if let Some(sender) = envelope.sender_hint.as_ref() {
+        match identity::read_identity_document(&sender.0) {
+            Ok(doc) => {
+                let ed_vk = doc
+                    .signing_keys
+                    .iter()
+                    .find(|k| k.algorithm == ALG_ED25519)
+                    .and_then(|k| STANDARD.decode(&k.public_key_b64).ok())
+                    .and_then(|b| <[u8; 32]>::try_from(b).ok());
+                let dil_pk = doc
+                    .signing_keys
+                    .iter()
+                    .find(|k| k.algorithm == ALG_MLDSA65)
+                    .and_then(|k| STANDARD.decode(&k.public_key_b64).ok());
+                (ed_vk, dil_pk)
+            }
+            Err(_) => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    let suite = HybridPqSuite::for_recipient(x25519_sk, kyber768_sk, sender_ed_vk, sender_dil_pk);
+
+    if let Some(sig) = envelope.outer_signature_b64.as_deref() {
+        match suite.verify_envelope(envelope, sig) {
+            Ok(()) => println!("classical_signature verified"),
+            Err(e) => println!("classical_signature FAILED: {}", e),
+        }
+    } else {
+        println!("classical_signature absent");
+    }
+
+    if let Some(pq_sig) = envelope.outer_pq_signature_b64.as_deref() {
+        match suite.verify_envelope_pq(envelope, pq_sig) {
+            Ok(()) => println!("pq_signature verified"),
+            Err(e) => println!("pq_signature FAILED: {}", e),
+        }
+    } else {
+        println!("pq_signature absent");
+    }
+
+    Ok(suite.decrypt_payload(&envelope.payload)?)
+}
+
+fn list(args: ListArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = state::fetched_envelope_dir(&args.recipient);
+    let entries = read_fetched_envelopes(&dir)?;
+    println!("recipient {}", args.recipient);
+    println!("count {}", entries.len());
+    for envelope in entries {
+        println!(
+            "{} {} {}",
+            envelope.created_at.to_rfc3339(),
+            envelope.envelope_id.0,
+            envelope_path(&dir, &envelope.envelope_id.0.to_string()).display()
+        );
+    }
+    Ok(())
+}
+
+fn resolve_sender(from: Option<String>) -> Result<Option<IdentityId>, Box<dyn std::error::Error>> {
+    match from {
+        Some(id_str) => {
+            let id = parse_identity_id(&id_str)
+                .map_err(|_| format!("invalid sender identity id: {}", id_str))?;
+            Ok(Some(id))
+        }
+        None => match identity::read_default_identity_id()? {
+            Some(id_str) => {
+                let id = parse_identity_id(&id_str)
+                    .map_err(|_| format!("invalid default identity id: {}", id_str))?;
+                Ok(Some(id))
+            }
+            None => Ok(None),
+        },
+    }
 }
 
 enum SignatureStatus {
@@ -193,21 +361,19 @@ impl SignatureStatus {
 
     fn reason(&self) -> Option<&str> {
         match self {
-            SignatureStatus::Failed(reason) | SignatureStatus::Unavailable(reason) => {
-                Some(reason.as_str())
-            }
+            SignatureStatus::Failed(r) | SignatureStatus::Unavailable(r) => Some(r.as_str()),
             SignatureStatus::Unsigned | SignatureStatus::Verified => None,
         }
     }
 }
 
-fn signature_status(envelope: &Envelope) -> SignatureStatus {
+fn demo_signature_status(envelope: &Envelope) -> SignatureStatus {
     let Some(signature) = envelope.outer_signature_b64.as_deref() else {
         return SignatureStatus::Unsigned;
     };
 
     let sender = match envelope.sender_hint.as_ref() {
-        Some(sender) => sender,
+        Some(s) => s,
         None => {
             return SignatureStatus::Unavailable(
                 "signature present but sender_hint missing".to_string(),
@@ -226,7 +392,7 @@ fn signature_status(envelope: &Envelope) -> SignatureStatus {
     };
 
     let signing_key = match sender_doc.signing_keys.first() {
-        Some(signing_key) => signing_key,
+        Some(k) => k,
         None => {
             return SignatureStatus::Unavailable(
                 "sender identity has no signing key records".to_string(),
@@ -235,7 +401,7 @@ fn signature_status(envelope: &Envelope) -> SignatureStatus {
     };
 
     let verify_suite = match DemoSuite::from_signing_key_b64(&signing_key.public_key_b64) {
-        Ok(suite) => suite,
+        Ok(s) => s,
         Err(err) => {
             return SignatureStatus::Unavailable(format!("invalid signing key metadata: {}", err))
         }
@@ -251,7 +417,6 @@ fn read_fetched_envelopes(dir: &Path) -> Result<Vec<Envelope>, Box<dyn std::erro
     if !dir.exists() {
         return Ok(Vec::new());
     }
-
     let mut out = Vec::new();
     for entry in fs::read_dir(dir)? {
         let path = entry?.path();
@@ -261,8 +426,7 @@ fn read_fetched_envelopes(dir: &Path) -> Result<Vec<Envelope>, Box<dyn std::erro
         let raw = fs::read_to_string(path)?;
         out.push(Envelope::from_json(&raw)?);
     }
-
-    out.sort_by_key(|envelope| Reverse(envelope.created_at));
+    out.sort_by_key(|e| Reverse(e.created_at));
     Ok(out)
 }
 
@@ -273,7 +437,7 @@ fn envelope_path(dir: &Path, envelope_id: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aegis_proto::{EncryptedBlob, IdentityId, SuiteId};
+    use aegis_proto::{EncryptedBlob, SuiteId};
 
     fn sample_envelope(recipient: &str, id_suffix: &str) -> Envelope {
         let mut envelope = Envelope::new(
@@ -283,6 +447,8 @@ mod tests {
             EncryptedBlob {
                 nonce_b64: "bm9uY2U=".to_string(),
                 ciphertext_b64: "Y2lwaGVydGV4dA==".to_string(),
+                eph_x25519_public_key_b64: None,
+                mlkem_ciphertext_b64: None,
             },
         );
         envelope.content_type = format!("message/private-{id_suffix}");
@@ -313,17 +479,17 @@ mod tests {
     }
 
     #[test]
-    fn signature_status_reports_unsigned() {
+    fn demo_signature_status_reports_unsigned() {
         let envelope = sample_envelope("amp:did:key:z6MkRecipient", "unsigned");
-        let status = signature_status(&envelope);
+        let status = demo_signature_status(&envelope);
         assert_eq!(status.label(), "unsigned");
     }
 
     #[test]
-    fn signature_status_reports_unavailable_without_sender_hint() {
+    fn demo_signature_status_reports_unavailable_without_sender_hint() {
         let mut envelope = sample_envelope("amp:did:key:z6MkRecipient", "signed");
         envelope.outer_signature_b64 = Some("c2ln".to_string());
-        let status = signature_status(&envelope);
+        let status = demo_signature_status(&envelope);
         assert_eq!(status.label(), "verification_unavailable");
     }
 }

--- a/src/commands/relay.rs
+++ b/src/commands/relay.rs
@@ -190,6 +190,8 @@ mod tests {
             EncryptedBlob {
                 nonce_b64: "bm9uY2U=".to_string(),
                 ciphertext_b64: "Y2lwaGVydGV4dA==".to_string(),
+                eph_x25519_public_key_b64: None,
+                mlkem_ciphertext_b64: None,
             },
         )
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,6 +75,10 @@ pub fn signing_key_material_path(identity_id: &str) -> PathBuf {
     ))
 }
 
+pub fn pq_key_material_path(identity_id: &str) -> PathBuf {
+    identities_dir().join(format!("{}.pq-key.json", sanitize_segment(identity_id)))
+}
+
 pub fn ensure_parent_dir(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
## Summary

- `aegit id init` now generates a full hybrid PQ key bundle and persists four public keys in the `IdentityDocument` (`AMP-X25519-V1`, `AMP-MLKEM768-V1`, `AMP-ED25519-V1`, `AMP-MLDSA65-V1`) plus a separate `<id>.pq-key.json` private key file
- `--include-demo-key` flag retains v0.1 signing key for backward compatibility
- `aegit msg seal` auto-detects PQ support from recipient's `IdentityDocument.supported_suites`; falls back to demo suite with `--passphrase`
- `aegit msg open` dispatches on `suite_id`; for HybridPq reports both classical and PQ signature verification results
- Adds `pq_key_material_path()` to `state.rs`; adds `base64 = "0.22"` dependency

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `aegit id init` produces `IdentityDocument` with 4 key records and a `.pq-key.json` file
- [ ] `aegit msg seal` to a PQ-capable recipient uses HybridPq suite without `--passphrase`
- [ ] `aegit msg open` on a HybridPq envelope reports `classical_sig_ok: true, pq_sig_ok: true`
- [ ] `--include-demo-key` retains classical-only signing key alongside PQ keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)