### PR TITLE
feat: aegit id publish command + relay-based recipient auto-resolve (v0.2.0-alpha)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,11 +33,11 @@ dependencies = [
  "pqcrypto-dilithium",
  "pqcrypto-kyber",
  "pqcrypto-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "x25519-dalek",
 ]
 
@@ -47,10 +47,15 @@ version = "0.1.0"
 dependencies = [
  "aegis-proto",
  "base64",
- "rand",
+ "ed25519-dalek",
+ "pqcrypto-dilithium",
+ "pqcrypto-traits",
+ "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -61,7 +66,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -77,6 +82,7 @@ dependencies = [
  "clap",
  "reqwest",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 
@@ -241,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -485,7 +497,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -637,8 +649,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -648,9 +662,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -803,6 +819,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1081,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1335,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,8 +1417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1350,7 +1438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1360,6 +1458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1388,6 +1495,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1395,6 +1504,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1402,6 +1512,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1417,6 +1528,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1447,6 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1459,6 +1577,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1601,7 +1720,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1725,7 +1844,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1733,6 +1861,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1750,6 +1889,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,7 +1914,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2081,6 +2247,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ aegis-proto = { path = "../aegis-core/crates/aegis-proto" }
 aegis-crypto = { path = "../aegis-core/crates/aegis-crypto" }
 aegis-identity = { path = "../aegis-core/crates/aegis-identity" }
 aegis-api-types = { path = "../aegis-core/crates/aegis-api-types" }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde_json = "1"
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 uuid = { version = "1", features = ["v4"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Default locations:
 - `aegit id list` lists stored identities and marks the default.
 
 `aegit msg seal` uses `--from` when provided. If omitted, it uses the default local identity. If no default identity exists, it returns a helpful error prompting `aegit id init`.
+When `--to` is not a canonical `IdentityId`, `aegit msg seal --relay <url>` can resolve aliases via relay resolver endpoint.
 
 Local-dev identity signing behavior:
 
@@ -91,7 +92,7 @@ CLI flows for `v0.1.0-alpha` are development-oriented.
 
 - demo crypto/signing is non-production
 - no production PQ cryptography
-- no production resolver integration
+- resolver integration is available through relay-backed identity/alias endpoints; production trust policy remains in-progress
 
 ## Development Workflow
 

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -228,6 +228,15 @@ fn publish(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     sign_identity_document(&mut doc, &ed25519_seed, &dilithium3_sk)?;
 
+    // Persist the signed document locally so future operations see the signature.
+    fs::write(&doc_path, serde_json::to_string_pretty(&doc)?).map_err(|e| {
+        format!(
+            "failed to write signed identity document {}: {}",
+            doc_path.display(),
+            e
+        )
+    })?;
+
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
@@ -237,7 +246,8 @@ fn publish(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
     ))?;
 
     println!("published {}", doc.identity_id.0);
-    println!("relay    {}", args.relay);
+    println!("relay     {}", args.relay);
+    println!("signed    {}", doc_path.display());
     Ok(())
 }
 

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -18,6 +18,15 @@ pub enum IdentityCommand {
     Init(InitArgs),
     Show(ShowArgs),
     List,
+    Publish(PublishArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct PublishArgs {
+    #[arg(long, env = "AEGIS_RELAY_URL")]
+    pub relay: String,
+    #[arg(long)]
+    pub identity: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -38,6 +47,7 @@ pub struct ShowArgs {
 
 pub fn run(cmd: IdentityCommand) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
+        IdentityCommand::Publish(args) => publish(args)?,
         IdentityCommand::Init(args) => {
             let id = IdentityId(format!("amp:did:key:local-{}", Uuid::new_v4().simple()));
             let alias_list = args.alias.into_iter().collect::<Vec<_>>();
@@ -182,6 +192,52 @@ pub fn run(cmd: IdentityCommand) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
+    Ok(())
+}
+
+fn publish(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use aegis_identity::sign_identity_document;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+    let identity_id = match args.identity {
+        Some(id) => id,
+        None => {
+            let path = state::default_identity_path();
+            fs::read_to_string(path)?.trim().to_string()
+        }
+    };
+
+    let doc_path = state::identity_doc_path(&identity_id);
+    let raw = fs::read_to_string(&doc_path).map_err(|e| {
+        format!(
+            "failed to read identity document {}: {}",
+            doc_path.display(),
+            e
+        )
+    })?;
+    let mut doc: aegis_proto::IdentityDocument = serde_json::from_str(&raw)
+        .map_err(|e| format!("invalid identity document {}: {}", doc_path.display(), e))?;
+
+    let pq_material = read_pq_key_material(&identity_id)?;
+
+    let ed25519_seed: [u8; 32] = STANDARD
+        .decode(&pq_material.ed25519_signing_seed_b64)?
+        .try_into()
+        .map_err(|_| "invalid ed25519 seed length")?;
+    let dilithium3_sk = STANDARD.decode(&pq_material.dilithium3_secret_key_b64)?;
+
+    sign_identity_document(&mut doc, &ed25519_seed, &dilithium3_sk)?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(aegis_identity::resolver::publish_identity(
+        &args.relay,
+        &doc,
+    ))?;
+
+    println!("published {}", doc.identity_id.0);
+    println!("relay    {}", args.relay);
     Ok(())
 }
 

--- a/src/commands/message.rs
+++ b/src/commands/message.rs
@@ -37,6 +37,9 @@ pub struct SealArgs {
     pub passphrase: Option<String>,
     #[arg(long)]
     pub out: Option<PathBuf>,
+    /// Relay URL for resolving recipient identity when not found locally.
+    #[arg(long, env = "AEGIS_RELAY_URL")]
+    pub relay: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -64,6 +67,10 @@ pub fn run(cmd: MessageCommand) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+fn read_identity_document_opt(identity_id: &str) -> Option<aegis_proto::IdentityDocument> {
+    identity::read_identity_document(identity_id).ok()
+}
+
 fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     let recipient_id = parse_identity_id(&args.to)
         .map_err(|_| format!("invalid recipient identity id: {}", args.to))?;
@@ -84,7 +91,30 @@ fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
         extensions: serde_json::json!({}),
     };
 
-    let recipient_doc = identity::read_identity_document(&recipient_id.0).ok();
+    // Try local store first; fall back to relay if a URL is configured.
+    let recipient_doc_opt = match read_identity_document_opt(&recipient_id.0) {
+        Some(doc) => Some(doc),
+        None => {
+            let relay_url = args.relay.clone();
+            match relay_url {
+                Some(url) => {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()?;
+                    Some(
+                        rt.block_on(aegis_identity::resolver::resolve_identity(
+                            &url,
+                            &recipient_id.0,
+                        ))
+                        .map_err(|e| format!("could not resolve recipient identity: {}", e))?,
+                    )
+                }
+                None => None,
+            }
+        }
+    };
+
+    let recipient_doc = recipient_doc_opt;
     let supports_pq = recipient_doc
         .as_ref()
         .map(|doc| doc.supported_suites.iter().any(|s| s == SUITE_HYBRID_PQ))

--- a/src/commands/message.rs
+++ b/src/commands/message.rs
@@ -72,8 +72,8 @@ fn read_identity_document_opt(identity_id: &str) -> Option<aegis_proto::Identity
 }
 
 fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let recipient_id = parse_identity_id(&args.to)
-        .map_err(|_| format!("invalid recipient identity id: {}", args.to))?;
+    let (recipient_id, resolved_recipient_doc) =
+        resolve_recipient_target(&args.to, args.relay.as_deref())?;
 
     let sender_hint = resolve_sender(args.from)?;
 
@@ -92,27 +92,28 @@ fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Try local store first; fall back to relay if a URL is configured.
-    let recipient_doc_opt = match read_identity_document_opt(&recipient_id.0) {
-        Some(doc) => Some(doc),
-        None => {
-            let relay_url = args.relay.clone();
-            match relay_url {
-                Some(url) => {
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()?;
-                    Some(
-                        rt.block_on(aegis_identity::resolver::resolve_identity(
-                            &url,
-                            &recipient_id.0,
-                        ))
-                        .map_err(|e| format!("could not resolve recipient identity: {}", e))?,
-                    )
+    let recipient_doc_opt =
+        match resolved_recipient_doc.or_else(|| read_identity_document_opt(&recipient_id.0)) {
+            Some(doc) => Some(doc),
+            None => {
+                let relay_url = args.relay.clone();
+                match relay_url {
+                    Some(url) => {
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()?;
+                        Some(
+                            rt.block_on(aegis_identity::resolver::resolve_identity(
+                                &url,
+                                &recipient_id.0,
+                            ))
+                            .map_err(|e| format!("could not resolve recipient identity: {}", e))?,
+                        )
+                    }
+                    None => None,
                 }
-                None => None,
             }
-        }
-    };
+        };
 
     let recipient_doc = recipient_doc_opt;
     let supports_pq = recipient_doc
@@ -196,6 +197,30 @@ fn seal(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn resolve_recipient_target(
+    to: &str,
+    relay: Option<&str>,
+) -> Result<(IdentityId, Option<aegis_proto::IdentityDocument>), Box<dyn std::error::Error>> {
+    if let Ok(id) = parse_identity_id(to) {
+        return Ok((id, None));
+    }
+
+    let relay_url = relay.ok_or_else(|| {
+        format!(
+            "recipient '{}' is not a valid identity id; pass --relay to resolve aliases",
+            to
+        )
+    })?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let doc = rt
+        .block_on(aegis_identity::resolver::resolve_alias(relay_url, to))
+        .map_err(|e| format!("could not resolve recipient alias '{}': {}", to, e))?;
+    Ok((doc.identity_id.clone(), Some(doc)))
 }
 
 fn write_envelope(


### PR DESCRIPTION
## Summary

- Adds `aegit id publish --relay <url>` subcommand: signs the default IdentityDocument with its own Ed25519+Dilithium3 keys, then publishes it to the relay via HTTP PUT
- `aegit msg seal` now falls back to network resolution (`AEGIS_RELAY_URL` or `--relay`) when a recipient's IdentityDocument is not found locally
- tokio single-thread runtime drives async resolver calls from the synchronous CLI context

## Test plan

- [ ] `cargo test -p aegit-cli` — 10 tests pass
- [ ] `cargo clippy` and `cargo fmt --check` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)