### PR TITLE
chore: refresh CHANGELOG for v0.2.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this repository are documented here.
 
 ## [Unreleased]
 
-- Ongoing `v0.1.0-alpha` stabilization and documentation alignment.
+- Ongoing `v0.2.0-alpha` stabilization.
+
+## [v0.2.0-alpha] - 2026-05-03
+
+### Crypto
+
+- PQ key generation via `aegit id init` produces hybrid X25519 + ML-KEM-768 material
+- `aegit msg seal` / `aegit msg open` auto-select the suite advertised by the recipient identity (hybrid PQ when available, demo otherwise)
+
+### Identity workflow
+
+- `aegit id publish` publishes the local identity document to a relay (`PUT /v1/identities/:id`)
+- `aegit msg seal` auto-resolves recipient identity via the relay's identity/alias endpoints when only an `amp:did:key:` or alias is supplied
 
 ## [v0.1.0-alpha] - 2026-04-29
 


### PR DESCRIPTION
## Summary
- Adds a `[v0.2.0-alpha] - 2026-05-03` section covering PRs #9–#10: PQ key generation, suite auto-selection on seal/open, `aegit id publish`, and relay-based recipient auto-resolve.
- Replaces the stale "ongoing v0.1.0-alpha stabilization" Unreleased note.

## Test plan
- [x] CHANGELOG renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)