### PR TITLE
chore: update SECURITY.md to disclose.io VDP format

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,47 @@
-# Security Policy
+# M&L AI Vulnerability Disclosure Policy
 
-## Status
+## Introduction
+M&L AI welcomes feedback from security researchers and the general public to help improve our security. If you believe you have discovered a vulnerability, privacy issue, exposed data, or other security issues in any of our assets, we want to hear from you. This policy outlines steps for reporting vulnerabilities to us, what we expect, what you can expect from us.
 
-This repository is part of the Aegis `v0.1.0-alpha` prototype effort.
+## Systems in Scope
+This policy applies to any digital assets owned, operated, or maintained by M&L AI.
 
-- It is not production-ready.
-- Demo crypto and experimental-PQ components are non-production.
-- Security properties may change as RFCs and implementations evolve.
+## Out of Scope
+Assets or other equipment not owned by parties participating in this policy.
 
-## Reporting a Vulnerability
+Vulnerabilities discovered or suspected in out-of-scope systems should be reported to the appropriate vendor or applicable authority.
 
-Please report suspected vulnerabilities privately to project maintainers rather than opening a public issue.
+## Our Commitments
+When working with us, according to this policy, you can expect us to:
+- Respond to your report promptly, and work with you to understand and validate your report;
+- Strive to keep you informed about the progress of a vulnerability as it is processed;
+- Work to remediate discovered vulnerabilities in a timely manner, within our operational constraints; and
+- Extend Safe Harbor for your vulnerability research that is related to this policy.
 
-Include:
+## Our Expectations
+In participating in our vulnerability disclosure program in good faith, we ask that you:
+- Play by the rules, including following this policy and any other relevant agreements. If there is any inconsistency between this policy and any other applicable terms, the terms of this policy will prevail;
+- Report any vulnerability you've discovered promptly;
+- Avoid violating the privacy of others, disrupting our systems, destroying data, and/or harming user experience;
+- Use only the Official Channels to discuss vulnerability information with us;
+- Provide us a reasonable amount of time (at least 90 days from the initial report) to resolve the issue before you disclose it publicly;
+- Perform testing only on in-scope systems, and respect systems and activities which are out-of-scope;
+- If a vulnerability provides unintended access to data: Limit the amount of data you access to the minimum required for effectively demonstrating a Proof of Concept; and cease testing and submit a report immediately if you encounter any user data during testing, such as Personally Identifiable Information (PII), Personal Healthcare Information (PHI), credit card data, or proprietary information;
+- You should only interact with test accounts you own or with explicit permission from the account holder; and
+- Do not engage in extortion.
 
-- affected repo and commit/version
-- reproduction steps and impact
-- whether identity, relay, gateway, or crypto boundaries are affected
+## Official Channels
+Please report security issues via [matthewd@matthewd.xyz](mailto:matthewd@matthewd.xyz) or [mdavisa2021@pm.me](mailto:mdavisa2021@pm.me), providing all relevant information. The more details you provide, the easier it will be for us to triage and fix the issue.
 
-Maintainers should acknowledge receipt and coordinate a fix/update path before public disclosure.
+## Safe Harbor
+When conducting vulnerability research, according to this policy, we consider this research conducted under this policy to be:
+- Authorized concerning any applicable anti-hacking laws, and we will not initiate or support legal action against you for accidental, good-faith violations of this policy;
+- Authorized concerning any relevant anti-circumvention laws, and we will not bring a claim against you for circumvention of technology controls;
+- Exempt from restrictions in our Terms of Service (TOS) and/or Acceptable Usage Policy (AUP) that would interfere with conducting security research, and we waive those restrictions on a limited basis; and
+- Lawful, helpful to the overall security of the Internet, and conducted in good faith.
 
-## Scope Notes
+You are expected, as always, to comply with all applicable laws. If legal action is initiated by a third party against you and you have complied with this policy, we will take steps to make it known that your actions were conducted in compliance with this policy.
 
-- Relay remains a zero-trust transport/storage component.
-- Gateway remains outside trusted core and is policy/scaffold oriented in alpha.
-- Production PQ/resolver/signature lifecycle guarantees are out of scope for v0.1.0-alpha.
+If at any time you have concerns or are uncertain whether your security research is consistent with this policy, please submit a report through one of our Official Channels before going any further.
+
+Note that the Safe Harbor applies only to legal claims under the control of the organization participating in this policy, and that the policy does not bind independent third parties.


### PR DESCRIPTION
Replaces the v0.1-era SECURITY.md with the standardized M&L AI Vulnerability Disclosure Policy (disclose.io format) per global repo conventions.