### PR TITLE
feat(cli): lifecycle output polish + error hints (closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this repository are documented here.
 
 ## [Unreleased]
 
+### Lifecycle output polish + error hints on `aegit relay ...` (closes #6)
+
+- Every relay subcommand now leads its stdout with a `status <verb>` line — `pushed` / `fetched` / `acknowledged` / `deleted` / `cleaned` — so quick-glance output answers "did it work?" first. Subsequent key=value lines are unchanged in spirit; some reordering for consistency.
+- **Bug fix**: `aegit relay cleanup` was silently dropping `old_removed` from its output (the relay returns it; the CLI just never printed it). Now prints all three counters: `expired_removed`, `orphan_ack_removed`, `old_removed`.
+- New 4xx/5xx error hint mapping. On non-2xx responses, the CLI now emits to stderr:
+  - The relay's structured `relay_error_code` + `relay_error_message` lines when the body decodes as `RelayErrorResponse` (raw body otherwise)
+  - A `hint:` line with operator-targeted guidance, varied by HTTP status × operation. Examples:
+    - `401` → `relay requires authentication. Pass --token, set AEGIS_RELAY_TOKEN, or add 'token = "..."' to ~/.aegis/aegit/config.toml`
+    - `403` → `token lacks the required scope (push needs PushEnvelope; ack/delete/cleanup need LifecycleChange; identity puts need IdentityWrite)`
+    - `404` on `ack` → `envelope not found (it may already have been acknowledged or deleted, or the recipient ID is wrong)`
+    - `404` on `delete` → similar but distinguishes "may already have been deleted"
+    - `404` on `fetch` → `no envelopes for recipient (or recipient ID is unknown to this relay)`
+    - `409` on `push` → `envelope rejected by relay (commonly: prekey already used or unknown). Re-claim a fresh prekey with 'aegit msg seal --relay ...' and retry.`
+    - `413` on `push` → mentions size limit
+    - generic `5xx` → `try again later`
+- 8 new unit tests on `relay_error_hint` cover each case + the 2xx-returns-None safety property.
+
 ### CLI config file support (closes #7)
 
 - New `~/.aegis/aegit/config.toml` config file with per-user defaults for `relay`, `token`, and `state_dir`. All keys optional. Override file location with `AEGIT_CONFIG=/path/to/config.toml`.

--- a/src/commands/relay.rs
+++ b/src/commands/relay.rs
@@ -4,11 +4,12 @@ use std::{
 };
 
 use aegis_api_types::{
-    EnvelopeLifecycleResponse, FetchEnvelopeResponse, RelayCleanupResponse, StoreEnvelopeRequest,
-    StoreEnvelopeResponse,
+    EnvelopeLifecycleResponse, FetchEnvelopeResponse, RelayCleanupResponse, RelayErrorResponse,
+    StoreEnvelopeRequest, StoreEnvelopeResponse,
 };
 use aegis_proto::Envelope;
 use clap::{Args, Subcommand};
+use reqwest::StatusCode;
 
 use crate::{config, state};
 
@@ -92,12 +93,14 @@ pub fn run(cmd: RelayCommand) -> Result<(), Box<dyn std::error::Error>> {
             let url = format!("{}/v1/envelopes", relay_url.trim_end_matches('/'));
             let req = client.post(url).json(&StoreEnvelopeRequest { envelope });
             let req = with_token(req, token.as_deref());
-            let resp: StoreEnvelopeResponse = req.send()?.error_for_status()?.json()?;
-            println!("pushed {}", args.input);
+            let resp = check_response(req.send()?, "push")?;
+            let parsed: StoreEnvelopeResponse = resp.json()?;
+            println!("status pushed");
+            println!("accepted {}", parsed.accepted);
             println!("id {}", envelope_id);
             println!("to {}", recipient_id);
-            println!("relay {}", resp.relay_id);
-            println!("accepted {}", resp.accepted);
+            println!("input {}", args.input);
+            println!("relay {}", parsed.relay_id);
         }
         RelayCommand::Fetch(args) => {
             let relay_url = config::resolve_relay_required(args.relay.as_deref())?;
@@ -109,13 +112,14 @@ pub fn run(cmd: RelayCommand) -> Result<(), Box<dyn std::error::Error>> {
                 args.recipient
             );
             let req = with_token(client.get(url), token.as_deref());
-            let resp = req.send()?.error_for_status()?;
+            let resp = check_response(req.send()?, "fetch")?;
             let data: FetchEnvelopeResponse = resp.json()?;
             let out = args
                 .out
                 .unwrap_or_else(|| state::fetched_envelope_dir(&args.recipient));
             let written = write_envelopes(&out, &data.envelopes)?;
-            println!("fetched {}", written.len());
+            println!("status fetched");
+            println!("count {}", written.len());
             println!("recipient {}", args.recipient);
             println!("dir {}", out.display());
             for path in written {
@@ -133,10 +137,11 @@ pub fn run(cmd: RelayCommand) -> Result<(), Box<dyn std::error::Error>> {
                 args.envelope_id
             );
             let req = with_token(client.post(url), token.as_deref());
-            let resp: EnvelopeLifecycleResponse = req.send()?.error_for_status()?.json()?;
-            println!("status {}", resp.status);
-            println!("recipient {}", resp.recipient_id);
-            println!("id {}", resp.envelope_id);
+            let resp = check_response(req.send()?, "ack")?;
+            let parsed: EnvelopeLifecycleResponse = resp.json()?;
+            println!("status {}", parsed.status);
+            println!("recipient {}", parsed.recipient_id);
+            println!("id {}", parsed.envelope_id);
         }
         RelayCommand::Delete(args) => {
             let relay_url = config::resolve_relay_required(args.relay.as_deref())?;
@@ -149,10 +154,11 @@ pub fn run(cmd: RelayCommand) -> Result<(), Box<dyn std::error::Error>> {
                 args.envelope_id
             );
             let req = with_token(client.delete(url), token.as_deref());
-            let resp: EnvelopeLifecycleResponse = req.send()?.error_for_status()?.json()?;
-            println!("status {}", resp.status);
-            println!("recipient {}", resp.recipient_id);
-            println!("id {}", resp.envelope_id);
+            let resp = check_response(req.send()?, "delete")?;
+            let parsed: EnvelopeLifecycleResponse = resp.json()?;
+            println!("status {}", parsed.status);
+            println!("recipient {}", parsed.recipient_id);
+            println!("id {}", parsed.envelope_id);
         }
         RelayCommand::Cleanup(args) => {
             let relay_url = config::resolve_relay_required(args.relay.as_deref())?;
@@ -160,12 +166,93 @@ pub fn run(cmd: RelayCommand) -> Result<(), Box<dyn std::error::Error>> {
             let client = reqwest::blocking::Client::new();
             let url = format!("{}/v1/cleanup", relay_url.trim_end_matches('/'));
             let req = with_token(client.post(url), token.as_deref());
-            let resp: RelayCleanupResponse = req.send()?.error_for_status()?.json()?;
-            println!("expired_removed {}", resp.expired_removed);
-            println!("orphan_ack_removed {}", resp.orphan_ack_removed);
+            let resp = check_response(req.send()?, "cleanup")?;
+            let parsed: RelayCleanupResponse = resp.json()?;
+            println!("status cleaned");
+            println!("expired_removed {}", parsed.expired_removed);
+            println!("orphan_ack_removed {}", parsed.orphan_ack_removed);
+            println!("old_removed {}", parsed.old_removed);
         }
     }
     Ok(())
+}
+
+/// Check an HTTP response for success. On 2xx, return the response for
+/// normal parsing. On 4xx/5xx, emit:
+///
+/// 1. A line-prefixed structured `relay_error_code` / `relay_error_message`
+///    when the body decodes as the relay's standard `RelayErrorResponse`
+///    (so operators see the relay's own error code, not just the HTTP one).
+/// 2. A `hint:` line on stderr suggesting the operator action that's
+///    likely to fix the failure (auth missing, prekey already used, ...).
+/// 3. A `Box<dyn Error>` carrying the HTTP status so the command exits
+///    non-zero.
+fn check_response(
+    resp: reqwest::blocking::Response,
+    op: &str,
+) -> Result<reqwest::blocking::Response, Box<dyn std::error::Error>> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body = resp.text().unwrap_or_default();
+    if let Ok(parsed) = serde_json::from_str::<RelayErrorResponse>(&body) {
+        eprintln!("relay_error_code {}", parsed.error.code);
+        eprintln!("relay_error_message {}", parsed.error.message);
+    } else if !body.is_empty() {
+        eprintln!("relay_error_body {}", body);
+    }
+    if let Some(hint) = relay_error_hint(status, op) {
+        eprintln!("hint: {}", hint);
+    }
+    Err(format!("relay returned status {}", status).into())
+}
+
+/// Map an HTTP status (and the operation that triggered it) to an
+/// operator-friendly hint. Pure function — used by `check_response` and
+/// directly by tests.
+fn relay_error_hint(status: StatusCode, op: &str) -> Option<String> {
+    match (status, op) {
+        (StatusCode::UNAUTHORIZED, _) => Some(
+            "relay requires authentication. Pass --token, set AEGIS_RELAY_TOKEN, \
+             or add `token = \"...\"` to ~/.aegis/aegit/config.toml"
+                .to_string(),
+        ),
+        (StatusCode::FORBIDDEN, _) => Some(
+            "token lacks the required scope for this operation \
+             (push needs PushEnvelope; ack/delete/cleanup need LifecycleChange; \
+             identity puts need IdentityWrite)"
+                .to_string(),
+        ),
+        (StatusCode::NOT_FOUND, "ack") => Some(
+            "envelope not found (it may already have been acknowledged or deleted, \
+             or the recipient ID is wrong)"
+                .to_string(),
+        ),
+        (StatusCode::NOT_FOUND, "delete") => Some(
+            "envelope not found (it may already have been deleted, \
+             or the recipient ID is wrong)"
+                .to_string(),
+        ),
+        (StatusCode::NOT_FOUND, "fetch") => Some(
+            "no envelopes for recipient (or recipient ID is unknown to this relay)".to_string(),
+        ),
+        (StatusCode::NOT_FOUND, _) => Some("relay endpoint or resource not found".to_string()),
+        (StatusCode::CONFLICT, "push") => Some(
+            "envelope rejected by relay (commonly: prekey already used or unknown). \
+             Re-claim a fresh prekey with `aegit msg seal --relay ...` and retry."
+                .to_string(),
+        ),
+        (StatusCode::PAYLOAD_TOO_LARGE, "push") => {
+            Some("envelope exceeds the relay's configured size limit".to_string())
+        }
+        (s, _) if s.is_client_error() => Some(format!(
+            "relay rejected the request ({}); check arguments and retry",
+            s
+        )),
+        (s, _) if s.is_server_error() => Some(format!("relay-side error ({}); try again later", s)),
+        _ => None,
+    }
 }
 
 fn with_token(
@@ -245,5 +332,75 @@ mod tests {
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
         assert_eq!(auth, "Bearer dev-token");
+    }
+
+    // ---- Issue #6: lifecycle output polish + error hints ----
+
+    #[test]
+    fn relay_error_hint_401_mentions_token_sources() {
+        let hint =
+            relay_error_hint(StatusCode::UNAUTHORIZED, "push").expect("401 should have a hint");
+        assert!(hint.contains("--token"));
+        assert!(hint.contains("AEGIS_RELAY_TOKEN"));
+        assert!(hint.contains("config.toml"));
+    }
+
+    #[test]
+    fn relay_error_hint_403_mentions_scopes() {
+        let hint = relay_error_hint(StatusCode::FORBIDDEN, "ack").expect("403 should have a hint");
+        assert!(hint.contains("scope"));
+        assert!(hint.contains("LifecycleChange"));
+    }
+
+    #[test]
+    fn relay_error_hint_404_distinguishes_ack_vs_delete_vs_fetch() {
+        let ack = relay_error_hint(StatusCode::NOT_FOUND, "ack").expect("ack hint");
+        let delete = relay_error_hint(StatusCode::NOT_FOUND, "delete").expect("delete hint");
+        let fetch = relay_error_hint(StatusCode::NOT_FOUND, "fetch").expect("fetch hint");
+        let other = relay_error_hint(StatusCode::NOT_FOUND, "cleanup").expect("default hint");
+
+        assert!(ack.contains("acknowledged"));
+        assert!(delete.contains("deleted"));
+        assert!(fetch.contains("recipient"));
+        assert!(other.contains("not found"));
+        // Verify ack/delete give different guidance — operator confusion
+        // between the two is the most common reported friction.
+        assert_ne!(ack, delete);
+    }
+
+    #[test]
+    fn relay_error_hint_409_on_push_mentions_prekey() {
+        let hint = relay_error_hint(StatusCode::CONFLICT, "push").expect("409 push hint");
+        assert!(hint.contains("prekey"));
+    }
+
+    #[test]
+    fn relay_error_hint_413_on_push_mentions_size() {
+        let hint = relay_error_hint(StatusCode::PAYLOAD_TOO_LARGE, "push").expect("413 hint");
+        assert!(hint.contains("size limit"));
+    }
+
+    #[test]
+    fn relay_error_hint_generic_5xx_says_try_later() {
+        let hint =
+            relay_error_hint(StatusCode::INTERNAL_SERVER_ERROR, "push").expect("5xx generic hint");
+        assert!(hint.contains("try again later"));
+    }
+
+    #[test]
+    fn relay_error_hint_generic_4xx_falls_through() {
+        // A 4xx with no specific case should still produce SOME hint
+        // (to avoid the "no hint at all" outcome being a regression
+        // signal), and it should mention the status.
+        let hint = relay_error_hint(StatusCode::BAD_REQUEST, "push").expect("4xx generic hint");
+        assert!(hint.contains("400"));
+    }
+
+    #[test]
+    fn relay_error_hint_2xx_returns_none() {
+        // 2xx never reaches the hint mapper in production; the helper
+        // should still return None for safety.
+        assert!(relay_error_hint(StatusCode::OK, "push").is_none());
+        assert!(relay_error_hint(StatusCode::CREATED, "push").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes mlaify/aegit-cli#6. Three improvements to `aegit relay {push,fetch,ack,delete,cleanup}` output, all under the issue scope ("output formatting and operator-facing clarity") with no protocol changes.

## What changed

### 1. Consistent leading `status <verb>` line

Every relay subcommand now leads stdout with one of: `status pushed` / `status fetched` / `status acknowledged` / `status deleted` / `status cleaned`. Quick-glance reads "did it work?" first; scripts can grep `^status `.

Before (push):
```
pushed envelope.json
id <uuid>
to amp:did:key:...
relay <uuid>
accepted true
```

After:
```
status pushed
accepted true
id <uuid>
to amp:did:key:...
input envelope.json
relay <uuid>
```

### 2. Bug fix: cleanup output was missing `old_removed`

`RelayCleanupResponse { expired_removed, orphan_ack_removed, old_removed }` was returning all three fields; the CLI printed only the first two. Now prints all three.

### 3. 4xx/5xx error hints

On non-2xx responses, stderr now emits:

- `relay_error_code` + `relay_error_message` lines when the body decodes as `RelayErrorResponse` (raw body otherwise)
- A `hint:` line with operator-targeted guidance, varied by HTTP status × operation:

| Status | Op | Hint sketch |
|---|---|---|
| 401 | any | `Pass --token, set AEGIS_RELAY_TOKEN, or add 'token = "..."' to config.toml` |
| 403 | any | `token lacks the required scope (PushEnvelope / LifecycleChange / IdentityWrite)` |
| 404 | ack | `may already have been acknowledged or deleted, or recipient ID is wrong` |
| 404 | delete | `may already have been deleted, or recipient ID is wrong` |
| 404 | fetch | `no envelopes for recipient (or recipient ID is unknown)` |
| 404 | other | `relay endpoint or resource not found` |
| 409 | push | `prekey already used or unknown; re-claim and retry` |
| 413 | push | `exceeds relay's configured size limit` |
| any 4xx | any | generic "relay rejected; check arguments" |
| any 5xx | any | `try again later` |

## Implementation

- New `check_response(resp, op)` helper centralizes success/error branching. Replaces per-command `.error_for_status()?`.
- New pure `relay_error_hint(status, op) -> Option<String>` — testable in isolation.

## Tests

`cargo test`: **52/52 pass** (was 44). 8 new tests cover hint mapping for each status × op variant + the `2xx → None` safety property.

`cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Compatibility

- Stdout reordered slightly (status now first); the *content* — every value previously printed — is preserved. Anything grepping for specific keys (`^id `, `^accepted `, `^recipient `) still works.
- `aegit relay cleanup` adds an `old_removed N` line that wasn't there before. Strict consumers should re-validate, but this fixes a pre-existing bug not a new feature.
- Errors now go to stderr (relay_error_*, hint:) — was previously buried in reqwest's `Box<dyn Error>` Display impl on stdout. Exit code unchanged.

## Test plan

- [x] `cargo build`
- [x] `cargo test` — 52/52
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`