### PR TITLE
feat(cli): resolver-aware identity lookup (closes #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this repository are documented here.
 
 ## [Unreleased]
 
+### Resolver-aware identity lookup (closes #5)
+
+- Wires the CLI through the new `aegis-identity::resolver::Resolver` trait (shipped in aegis-core PR #21). The five resolver call sites — `aegit msg seal` (alias resolution, identity resolution, prekey claim), `aegit id publish`, `aegit id publish-prekeys` — now construct an `HttpResolver` instance and go through trait methods instead of free functions. Behavior unchanged; behavior contract is now testable.
+- New testable async helper `resolve_recipient_target_with<R: Resolver>(to, resolver)` extracts the alias-resolution branch of `resolve_recipient_target`. The sync entry point still drives the seal command; the async helper is the seam.
+- 4 new pure-local tests use `aegis_identity::resolver::StaticResolver` (no HTTP) to validate fallback behavior:
+  - Canonical `amp:did:key:*` identifier short-circuits — resolver is never queried
+  - Known alias resolves and returns the cached doc for downstream PQ-suite detection
+  - Unknown alias surfaces a descriptive error mentioning the alias name
+  - The doc returned by an alias hit is `Some(...)` (regression guard for the supports_pq path)
+- Local-dev default behavior preserved: free-function wrappers in core are still valid; the CLI just now goes through `HttpResolver` directly so consumers reading the source can see the resolver-aware code path.
+
 ### Lifecycle output polish + error hints on `aegit relay ...` (closes #6)
 
 - Every relay subcommand now leads its stdout with a `status <verb>` line — `pushed` / `fetched` / `acknowledged` / `deleted` / `cleaned` — so quick-glance output answers "did it work?" first. Subsequent key=value lines are unchanged in spirit; some reordering for consistency.

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -3,9 +3,9 @@ use std::fs;
 use aegis_crypto::HybridPqKeyBundle;
 use aegis_identity::{
     decode_local_dev_signing_key, generate_local_dev_signing_key_material, generate_prekey_bundle,
-    parse_identity_id, sign_prekey_bundle, HybridPqPrivateKeyMaterial, LocalDevSigningKeyMaterial,
-    PrekeyBundlePrivateMaterial, ALG_ED25519, ALG_MLDSA65, ALG_MLKEM768, ALG_X25519,
-    SUITE_HYBRID_PQ,
+    parse_identity_id, resolver::Resolver, sign_prekey_bundle, HybridPqPrivateKeyMaterial,
+    LocalDevSigningKeyMaterial, PrekeyBundlePrivateMaterial, ALG_ED25519, ALG_MLDSA65,
+    ALG_MLKEM768, ALG_X25519, SUITE_HYBRID_PQ,
 };
 use aegis_proto::{IdentityDocument, IdentityId, PublicKeyRecord};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
@@ -256,10 +256,8 @@ fn publish(args: PublishArgs) -> Result<(), Box<dyn std::error::Error>> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    rt.block_on(aegis_identity::resolver::publish_identity(
-        &args.relay,
-        &doc,
-    ))?;
+    let resolver = aegis_identity::resolver::HttpResolver::new(args.relay.as_str());
+    rt.block_on(resolver.publish_identity(&doc))?;
 
     println!("published {}", doc.identity_id.0);
     println!("relay     {}", args.relay);
@@ -317,10 +315,8 @@ fn publish_prekeys(args: PublishPrekeysArgs) -> Result<(), Box<dyn std::error::E
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    rt.block_on(aegis_identity::resolver::publish_prekey_bundle(
-        &args.relay,
-        &bundle,
-    ))?;
+    let resolver = aegis_identity::resolver::HttpResolver::new(args.relay.as_str());
+    rt.block_on(resolver.publish_prekey_bundle(&bundle))?;
 
     println!("published_prekeys {}", bundle.identity_id.0);
     println!("relay             {}", args.relay);

--- a/src/commands/message.rs
+++ b/src/commands/message.rs
@@ -9,8 +9,9 @@ use aegis_crypto::{
     SignatureCheck, SignaturePolicy, VerificationOutcome,
 };
 use aegis_identity::{
-    decode_local_dev_signing_key, parse_identity_id, PrekeyBundlePrivateMaterial, ALG_ED25519,
-    ALG_MLDSA65, ALG_MLKEM768, ALG_X25519, SUITE_HYBRID_PQ,
+    decode_local_dev_signing_key, parse_identity_id, resolver::Resolver,
+    PrekeyBundlePrivateMaterial, ALG_ED25519, ALG_MLDSA65, ALG_MLKEM768, ALG_X25519,
+    SUITE_HYBRID_PQ,
 };
 use aegis_proto::{Envelope, IdentityId, MessageBody, PrivateHeaders, PrivatePayload, SuiteId};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
@@ -152,28 +153,27 @@ fn seal(mut args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Try local store first; fall back to relay if a URL is configured.
-    let recipient_doc_opt =
-        match resolved_recipient_doc.or_else(|| read_identity_document_opt(&recipient_id.0)) {
-            Some(doc) => Some(doc),
-            None => {
-                let relay_url = args.relay.clone();
-                match relay_url {
-                    Some(url) => {
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()?;
-                        Some(
-                            rt.block_on(aegis_identity::resolver::resolve_identity(
-                                &url,
-                                &recipient_id.0,
-                            ))
+    let recipient_doc_opt = match resolved_recipient_doc
+        .or_else(|| read_identity_document_opt(&recipient_id.0))
+    {
+        Some(doc) => Some(doc),
+        None => {
+            let relay_url = args.relay.clone();
+            match relay_url {
+                Some(url) => {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()?;
+                    let resolver = aegis_identity::resolver::HttpResolver::new(url.as_str());
+                    Some(
+                        rt.block_on(resolver.resolve_identity(&recipient_id.0))
                             .map_err(|e| format!("could not resolve recipient identity: {}", e))?,
-                        )
-                    }
-                    None => None,
+                    )
                 }
+                None => None,
             }
-        };
+        }
+    };
 
     let recipient_doc = recipient_doc_opt;
     let supports_pq = recipient_doc
@@ -208,10 +208,8 @@ fn seal(mut args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()?;
-                match rt.block_on(aegis_identity::resolver::claim_one_time_prekey(
-                    relay_url,
-                    &recipient_id.0,
-                )) {
+                let resolver = aegis_identity::resolver::HttpResolver::new(relay_url.as_str());
+                match rt.block_on(resolver.claim_one_time_prekey(&recipient_id.0)) {
                     Ok(claimed) => {
                         if claimed.algorithm != ALG_MLKEM768 {
                             return Err(format!(
@@ -332,8 +330,27 @@ fn resolve_recipient_target(
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let doc = rt
-        .block_on(aegis_identity::resolver::resolve_alias(relay_url, to))
+    let resolver = aegis_identity::resolver::HttpResolver::new(relay_url);
+    rt.block_on(resolve_recipient_target_with(to, &resolver))
+}
+
+/// Resolver-aware variant of [`resolve_recipient_target`]. Pure async,
+/// generic over any [`Resolver`] impl. Fast-path for canonical
+/// `amp:did:key:` identifiers (returns without touching the resolver);
+/// otherwise calls `resolve_alias` on the resolver.
+///
+/// This is the **testable seam** for #5 — tests pass a `StaticResolver`
+/// to exercise alias-resolution behavior without any HTTP.
+async fn resolve_recipient_target_with<R: aegis_identity::resolver::Resolver>(
+    to: &str,
+    resolver: &R,
+) -> Result<(IdentityId, Option<aegis_proto::IdentityDocument>), Box<dyn std::error::Error>> {
+    if let Ok(id) = parse_identity_id(to) {
+        return Ok((id, None));
+    }
+    let doc = resolver
+        .resolve_alias(to)
+        .await
         .map_err(|e| format!("could not resolve recipient alias '{}': {}", to, e))?;
     Ok((doc.identity_id.clone(), Some(doc)))
 }
@@ -858,6 +875,95 @@ mod tests {
         SignatureCheck::Failed {
             reason: reason.to_string(),
         }
+    }
+
+    // ----- Issue aegit-cli#5: resolver-aware identity lookup -----
+    //
+    // The async helper resolve_recipient_target_with takes any
+    // `R: Resolver`, so tests use aegis_identity::resolver::StaticResolver
+    // (pure local, no HTTP). This validates the "tests for fallback
+    // behavior" acceptance criterion:
+    //
+    //   1. Canonical amp:did:key:* → short-circuit, never touch resolver
+    //   2. Alias known to resolver → resolved + returned with doc
+    //   3. Alias unknown to resolver → propagates ResolverError::NotFound
+    //      with a descriptive error message
+
+    use aegis_identity::resolver::StaticResolver;
+    use aegis_proto::IdentityDocument as ProtoDoc;
+
+    fn sample_identity_doc(id: &str, alias: &str) -> ProtoDoc {
+        ProtoDoc {
+            version: 1,
+            identity_id: IdentityId(id.to_string()),
+            aliases: vec![alias.to_string()],
+            signing_keys: vec![],
+            encryption_keys: vec![],
+            supported_suites: vec!["AMP-DEMO-XCHACHA20POLY1305".to_string()],
+            relay_endpoints: vec![],
+            signature: None,
+        }
+    }
+
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt")
+            .block_on(fut)
+    }
+
+    #[test]
+    fn resolve_recipient_target_with_canonical_id_short_circuits() {
+        let resolver = StaticResolver::new(); // never queried
+        let result = block_on(resolve_recipient_target_with(
+            "amp:did:key:z6MkCanonical",
+            &resolver,
+        ))
+        .expect("canonical id");
+        let (id, doc) = result;
+        assert_eq!(id.0, "amp:did:key:z6MkCanonical");
+        assert!(
+            doc.is_none(),
+            "no doc returned for canonical id; resolver was not called",
+        );
+    }
+
+    #[test]
+    fn resolve_recipient_target_with_alias_resolves_via_static_resolver() {
+        let doc = sample_identity_doc("amp:did:key:z6MkAlice", "alice@mesh");
+        let resolver = StaticResolver::new().with_alias("alice@mesh", doc.clone());
+        let (id, returned_doc) = block_on(resolve_recipient_target_with("alice@mesh", &resolver))
+            .expect("alias resolved");
+        assert_eq!(id.0, "amp:did:key:z6MkAlice");
+        let returned_doc = returned_doc.expect("doc returned");
+        assert_eq!(returned_doc.identity_id.0, "amp:did:key:z6MkAlice");
+    }
+
+    #[test]
+    fn resolve_recipient_target_with_unknown_alias_propagates_error() {
+        let resolver = StaticResolver::new();
+        let err = block_on(resolve_recipient_target_with("ghost@mesh", &resolver))
+            .expect_err("alias unknown");
+        let msg = err.to_string();
+        // Error wrapping preserved: descriptive message + alias name.
+        assert!(
+            msg.contains("could not resolve recipient alias 'ghost@mesh'"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_recipient_target_with_alias_returns_doc_for_caching() {
+        // The doc returned by alias resolution is what downstream code uses
+        // to discover supported_suites + encryption_keys. The Some(doc)
+        // path is the supports_pq → claim_prekey path; make sure we don't
+        // accidentally regress to None.
+        let doc = sample_identity_doc("amp:did:key:z6MkAlice", "alice@mesh");
+        let resolver = StaticResolver::new().with_alias("alice@mesh", doc);
+        let (_, returned) =
+            block_on(resolve_recipient_target_with("alice@mesh", &resolver)).expect("ok");
+        assert!(returned.is_some(), "alias path must return the doc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes mlaify/aegit-cli#5 — wires the CLI through the new `aegis-identity::resolver::Resolver` trait shipped in mlaify/aegis-core#21. The five resolver call sites now construct an `HttpResolver` and go through trait methods instead of free functions. **Behavior unchanged**; behavior contract is now testable.

## Call sites refactored

| File | Function | Resolver method |
|---|---|---|
| `commands/message.rs` | `seal` — alias resolution via `resolve_recipient_target` | `resolve_alias` |
| `commands/message.rs` | `seal` — PQ-detection branch identity resolution | `resolve_identity` |
| `commands/message.rs` | `seal` — prekey claim | `claim_one_time_prekey` |
| `commands/identity.rs` | `publish` | `publish_identity` |
| `commands/identity.rs` | `publish_prekeys` | `publish_prekey_bundle` |

## Testable seam

New pure async helper:

```rust
async fn resolve_recipient_target_with<R: Resolver>(
    to: &str,
    resolver: &R,
) -> Result<(IdentityId, Option<IdentityDocument>), Box<dyn Error>>
```

Extracts the alias-resolution branch of `resolve_recipient_target`. The existing sync entry point now constructs an `HttpResolver` and delegates. Downstream code that imports this helper can pass a `StaticResolver` for offline tests.

## Tests

4 new pure-local tests using `aegis_identity::resolver::StaticResolver` (no HTTP):

- Canonical `amp:did:key:*` identifier short-circuits — resolver is never queried
- Known alias resolves and returns the cached doc (validates the supports_pq path's doc-cached optimization)
- Unknown alias surfaces a descriptive error mentioning the alias name
- The doc returned by an alias hit is `Some(...)` (regression guard)

`cargo test`: **56/56 pass** (was 52). `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Compatibility

- Local-dev default behavior preserved (the issue's explicit acceptance criterion). The free-function wrappers in `aegis-identity::resolver` still work; the CLI just now uses the trait methods directly.
- No CLI flag or output changes.
- No new deps.

## Out of scope

- Letting the CLI inject a custom `Resolver` at runtime (e.g. for an offline-test mode). Today the CLI always constructs `HttpResolver(args.relay)`. The trait makes this *possible* — adding a `--resolver static-from-file` flag or similar is follow-up work, not required by #5.

## Test plan

- [x] `cargo build`
- [x] `cargo test` — 56/56
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`